### PR TITLE
Fixing platform specific string inconsistency

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,6 +12,10 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13.3'
       - name: Running tests
         run: |
           pip install coverage

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,5 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.13.3'
-      - name: Check python version
-        run: python --version
       - name: Running tests
         run: python -m unittest discover test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
-      - name: Check zlib version
-        run: python -c "import zlib; print(zlib.__version__)"
+      - name: Check python version
+        run: python --version
       - name: Running tests
         run: python -m unittest discover test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,5 +7,7 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
+      - name: Check zlib version
+        run: python -c "import zlib; print(zlib.__version__)"
       - name: Running tests
         run: python -m unittest discover test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,10 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13.3'
       - name: Check python version
         run: python --version
       - name: Running tests

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ monero_payment_request_data = monerorequest.decode_monero_payment_request(monero
 * For changes to the protocol, see [the payment request standard project](https://github.com/lukeprofits/Monero_Payment_Request_Standard)
 * There are no dependencies for the project besides python.
 * To run the tests locally run `python -m unittest discover test`
+* If you aren't using at least Python 3.13.3, you may have issues running the tests locally with some tests for the monerorequest output strings to fail, these are safe to ignore so long as you haven't made changes that would change the strings.
 * If you want to run the coverage check locally before opening a PR, install `coverage` and run `coverage html --include='./src/**'` and open `./htmlcov/index.html` in your browser.
 * If you want to run the linting check locally before opening a PR, install `ruff` and run `ruff check .`, if there is no output that means there are no errors.
 * To build the package run `python -m build`

--- a/src/monerorequest/encode.py
+++ b/src/monerorequest/encode.py
@@ -26,7 +26,7 @@ class Encode:
         # Convert the JSON data to a string
         json_str = json.dumps(json_data, separators=(',', ':'), sort_keys=True)
         # Compress the string using gzip compression
-        compressed_data = gzip.compress(json_str.encode('utf-8'), mtime=0)
+        compressed_data = gzip.compress(json_str.encode('utf-8'), mtime=0, compresslevel=6)
         # Encode the compressed data into a Base64-encoded string
         encoded_str = base64.b64encode(compressed_data).decode('ascii')
         return encoded_str

--- a/test/test_monerorequest.py
+++ b/test/test_monerorequest.py
@@ -30,7 +30,7 @@ class TestMoneroRequest(unittest.TestCase):
             'currency': 'USD', 'amount': '10.00', 'payment_id': 'bc4c07f4c46ed2fb', 'start_date': '2024-09-05T19:18:15.430Z',
             'days_per_billing_cycle': 1, 'number_of_payments': 10, 'change_indicator_url': '', 'version': '1'
         }
-        request_string = 'monero-request:1:H4sIAAAAAAACAy2OS0/DMBCE/4vPbeWkTktyS0qCBAKJtpTSi+XH5iEcu7IdIEH8dxzEaXe+Wc3ON2K9GbRHGYrwCmO0QKJlugHaadkJ5o2lg1XBnp3BWtBiDOrlcPsHnDc9VYzDfOLB+UAlGx29gqW8U6rTDRWjUICyaIH00PNgmJpe2diD9i5gvED/inYyxHBBBN7WRJANyLjmIdKBUmAd/WRhzmVJ7tfnxH6cxuvR1E0/wFPq0mdvJ7mHpBigsu49v3TRtjBvvJ1GZ6bJPFbFZnrVxwd5t9vkX2XOyzIRU7Vft2G7564n7Q7O8WF+6Zn1VDIfmqMYx2SJ0yVOjlGaRTdZlKzIGl/Qzy/yB8wvQQEAAA=='
+        request_string = 'monero-request:1:H4sIAAAAAAAA/y2OS0/DMBCE/4vPbeWkTktyS0qCBAKJtpTSi+XH5iEcu7IdIEH8dxzEaXe+Wc3ON2K9GbRHGYrwCmO0QKJlugHaadkJ5o2lg1XBnp3BWtBiDOrlcPsHnDc9VYzDfOLB+UAlGx29gqW8U6rTDRWjUICyaIH00PNgmJpe2diD9i5gvED/inYyxHBBBN7WRJANyLjmIdKBUmAd/WRhzmVJ7tfnxH6cxuvR1E0/wFPq0mdvJ7mHpBigsu49v3TRtjBvvJ1GZ6bJPFbFZnrVxwd5t9vkX2XOyzIRU7Vft2G7564n7Q7O8WF+6Zn1VDIfmqMYx2SJ0yVOjlGaRTdZlKzIGl/Qzy/yB8wvQQEAAA=='
         self.assertEqual(decode_monero_payment_request(request_string), payment_request)
 
     def test_make_monero_payment_request_v1(self):
@@ -41,7 +41,7 @@ class TestMoneroRequest(unittest.TestCase):
         }
         request_string = make_monero_payment_request(**payment_request)
         self.maxDiff = None
-        self.assertEqual(request_string, 'monero-request:1:H4sIAAAAAAACAy2OS0/DMBCE/4vPbeWkTktyS0qCBAKJtpTSi+XH5iEcu7IdIEH8dxzEaXe+Wc3ON2K9GbRHGYrwCmO0QKJlugHaadkJ5o2lg1XBnp3BWtBiDOrlcPsHnDc9VYzDfOLB+UAlGx29gqW8U6rTDRWjUICyaIH00PNgmJpe2diD9i5gvED/inYyxHBBBN7WRJANyLjmIdKBUmAd/WRhzmVJ7tfnxH6cxuvR1E0/wFPq0mdvJ7mHpBigsu49v3TRtjBvvJ1GZ6bJPFbFZnrVxwd5t9vkX2XOyzIRU7Vft2G7564n7Q7O8WF+6Zn1VDIfmqMYx2SJ0yVOjlGaRTdZlKzIGl/Qzy/yB8wvQQEAAA==')
+        self.assertEqual(request_string, 'monero-request:1:H4sIAAAAAAAA/y2OS0/DMBCE/4vPbeWkTktyS0qCBAKJtpTSi+XH5iEcu7IdIEH8dxzEaXe+Wc3ON2K9GbRHGYrwCmO0QKJlugHaadkJ5o2lg1XBnp3BWtBiDOrlcPsHnDc9VYzDfOLB+UAlGx29gqW8U6rTDRWjUICyaIH00PNgmJpe2diD9i5gvED/inYyxHBBBN7WRJANyLjmIdKBUmAd/WRhzmVJ7tfnxH6cxuvR1E0/wFPq0mdvJ7mHpBigsu49v3TRtjBvvJ1GZ6bJPFbFZnrVxwd5t9vkX2XOyzIRU7Vft2G7564n7Q7O8WF+6Zn1VDIfmqMYx2SJ0yVOjlGaRTdZlKzIGl/Qzy/yB8wvQQEAAA==')
 
     def test_make_monero_payment_request_v1_w_defaults(self):
         payment_request = {
@@ -67,7 +67,7 @@ class TestMoneroRequest(unittest.TestCase):
             'currency': 'USD', 'amount': '10.00', 'payment_id': 'bc4c07f4c46ed2fb', 'start_date': '2024-09-05T19:18:15.430Z',
             'schedule': '* * * * *', 'number_of_payments': 10, 'change_indicator_url': '', 'version': '2'
         }
-        request_string = 'monero-request:2:H4sIAAAAAAACAy1O206DQBD9FbOPpm0WWFrhDSo10WhiW7X2ZbOXoRBht9mLCsZ/dzHNPMycW+b8INZrrxzKUYQXGKMZEg1TJ6Ctkq1gThvqTRfkSfHGgBJDQC+723/COt3TjnGYLA6sC6zyPQdDdU3PbOhBOYvyCM/QBdFWBi8XROBVTQRZgoxrHnJWNCB9B0G9vrrMREPXgbH0i4U9FSWFSw6p+Xwdzntdn3oPT5nNnp0Z5RbS0sPG2I/i2EarUr/zZhysHkf9uCmX45vaP8i79bL4rgpeVakYN9ukCdc9tz1p1nCId9NLx4yjkrmpS4xjMsfZHKf7KMujmzxKFyTBR/T7BxO/cqM9AQAA'
+        request_string = 'monero-request:2:H4sIAAAAAAAA/y1O206DQBD9FbOPpm0WWFrhDSo10WhiW7X2ZbOXoRBht9mLCsZ/dzHNPMycW+b8INZrrxzKUYQXGKMZEg1TJ6Ctkq1gThvqTRfkSfHGgBJDQC+723/COt3TjnGYLA6sC6zyPQdDdU3PbOhBOYvyCM/QBdFWBi8XROBVTQRZgoxrHnJWNCB9B0G9vrrMREPXgbH0i4U9FSWFSw6p+Xwdzntdn3oPT5nNnp0Z5RbS0sPG2I/i2EarUr/zZhysHkf9uCmX45vaP8i79bL4rgpeVakYN9ukCdc9tz1p1nCId9NLx4yjkrmpS4xjMsfZHKf7KMujmzxKFyTBR/T7BxO/cqM9AQAA'
         self.assertEqual(decode_monero_payment_request(request_string), payment_request)
 
     def test_make_monero_payment_request_v2(self):
@@ -78,4 +78,4 @@ class TestMoneroRequest(unittest.TestCase):
         }
         request_string = make_monero_payment_request(**payment_request)
         self.maxDiff = None
-        self.assertEqual(request_string, 'monero-request:2:H4sIAAAAAAACAy1O206DQBD9FbOPpm0WWFrhDSo10WhiW7X2ZbOXoRBht9mLCsZ/dzHNPMycW+b8INZrrxzKUYQXGKMZEg1TJ6Ctkq1gThvqTRfkSfHGgBJDQC+723/COt3TjnGYLA6sC6zyPQdDdU3PbOhBOYvyCM/QBdFWBi8XROBVTQRZgoxrHnJWNCB9B0G9vrrMREPXgbH0i4U9FSWFSw6p+Xwdzntdn3oPT5nNnp0Z5RbS0sPG2I/i2EarUr/zZhysHkf9uCmX45vaP8i79bL4rgpeVakYN9ukCdc9tz1p1nCId9NLx4yjkrmpS4xjMsfZHKf7KMujmzxKFyTBR/T7BxO/cqM9AQAA')
+        self.assertEqual(request_string, 'monero-request:2:H4sIAAAAAAAA/y1O206DQBD9FbOPpm0WWFrhDSo10WhiW7X2ZbOXoRBht9mLCsZ/dzHNPMycW+b8INZrrxzKUYQXGKMZEg1TJ6Ctkq1gThvqTRfkSfHGgBJDQC+723/COt3TjnGYLA6sC6zyPQdDdU3PbOhBOYvyCM/QBdFWBi8XROBVTQRZgoxrHnJWNCB9B0G9vrrMREPXgbH0i4U9FSWFSw6p+Xwdzntdn3oPT5nNnp0Z5RbS0sPG2I/i2EarUr/zZhysHkf9uCmX45vaP8i79bL4rgpeVakYN9ukCdc9tz1p1nCId9NLx4yjkrmpS4xjMsfZHKf7KMujmzxKFyTBR/T7BxO/cqM9AQAA')

--- a/test/test_monerorequest.py
+++ b/test/test_monerorequest.py
@@ -30,7 +30,7 @@ class TestMoneroRequest(unittest.TestCase):
             'currency': 'USD', 'amount': '10.00', 'payment_id': 'bc4c07f4c46ed2fb', 'start_date': '2024-09-05T19:18:15.430Z',
             'days_per_billing_cycle': 1, 'number_of_payments': 10, 'change_indicator_url': '', 'version': '1'
         }
-        request_string = 'monero-request:1:H4sIAAAAAAAAAy2OS0/DMBCE/4vPbeWkTktyS0qCBAKJtpTSi+XH5iEcu7IdIEH8dxzEaXe+Wc3ON2K9GbRHGYrwCmO0QKJlugHaadkJ5o2lg1XBnp3BWtBiDOrlcPsHnDc9VYzDfOLB+UAlGx29gqW8U6rTDRWjUICyaIH00PNgmJpe2diD9i5gvED/inYyxHBBBN7WRJANyLjmIdKBUmAd/WRhzmVJ7tfnxH6cxuvR1E0/wFPq0mdvJ7mHpBigsu49v3TRtjBvvJ1GZ6bJPFbFZnrVxwd5t9vkX2XOyzIRU7Vft2G7564n7Q7O8WF+6Zn1VDIfmqMYx2SJ0yVOjlGaRTdZlKzIGl/Qzy/yB8wvQQEAAA=='
+        request_string = 'monero-request:1:H4sIAAAAAAAA/y2OS0/DMBCE/4vPbeWkTktyS0qCBAKJtpTSi+XH5iEcu7IdIEH8dxzEaXe+Wc3ON2K9GbRHGYrwCmO0QKJlugHaadkJ5o2lg1XBnp3BWtBiDOrlcPsHnDc9VYzDfOLB+UAlGx29gqW8U6rTDRWjUICyaIH00PNgmJpe2diD9i5gvED/inYyxHBBBN7WRJANyLjmIdKBUmAd/WRhzmVJ7tfnxH6cxuvR1E0/wFPq0mdvJ7mHpBigsu49v3TRtjBvvJ1GZ6bJPFbFZnrVxwd5t9vkX2XOyzIRU7Vft2G7564n7Q7O8WF+6Zn1VDIfmqMYx2SJ0yVOjlGaRTdZlKzIGl/Qzy/yB8wvQQEAAA=='
         self.assertEqual(decode_monero_payment_request(request_string), payment_request)
 
     def test_make_monero_payment_request_v1(self):
@@ -41,7 +41,7 @@ class TestMoneroRequest(unittest.TestCase):
         }
         request_string = make_monero_payment_request(**payment_request)
         self.maxDiff = None
-        self.assertEqual(request_string, 'monero-request:1:H4sIAAAAAAAAAy2OS0/DMBCE/4vPbeWkTktyS0qCBAKJtpTSi+XH5iEcu7IdIEH8dxzEaXe+Wc3ON2K9GbRHGYrwCmO0QKJlugHaadkJ5o2lg1XBnp3BWtBiDOrlcPsHnDc9VYzDfOLB+UAlGx29gqW8U6rTDRWjUICyaIH00PNgmJpe2diD9i5gvED/inYyxHBBBN7WRJANyLjmIdKBUmAd/WRhzmVJ7tfnxH6cxuvR1E0/wFPq0mdvJ7mHpBigsu49v3TRtjBvvJ1GZ6bJPFbFZnrVxwd5t9vkX2XOyzIRU7Vft2G7564n7Q7O8WF+6Zn1VDIfmqMYx2SJ0yVOjlGaRTdZlKzIGl/Qzy/yB8wvQQEAAA==')
+        self.assertEqual(request_string, 'monero-request:1:H4sIAAAAAAAA/y2OS0/DMBCE/4vPbeWkTktyS0qCBAKJtpTSi+XH5iEcu7IdIEH8dxzEaXe+Wc3ON2K9GbRHGYrwCmO0QKJlugHaadkJ5o2lg1XBnp3BWtBiDOrlcPsHnDc9VYzDfOLB+UAlGx29gqW8U6rTDRWjUICyaIH00PNgmJpe2diD9i5gvED/inYyxHBBBN7WRJANyLjmIdKBUmAd/WRhzmVJ7tfnxH6cxuvR1E0/wFPq0mdvJ7mHpBigsu49v3TRtjBvvJ1GZ6bJPFbFZnrVxwd5t9vkX2XOyzIRU7Vft2G7564n7Q7O8WF+6Zn1VDIfmqMYx2SJ0yVOjlGaRTdZlKzIGl/Qzy/yB8wvQQEAAA==')
 
     def test_make_monero_payment_request_v1_w_defaults(self):
         payment_request = {
@@ -67,7 +67,7 @@ class TestMoneroRequest(unittest.TestCase):
             'currency': 'USD', 'amount': '10.00', 'payment_id': 'bc4c07f4c46ed2fb', 'start_date': '2024-09-05T19:18:15.430Z',
             'schedule': '* * * * *', 'number_of_payments': 10, 'change_indicator_url': '', 'version': '2'
         }
-        request_string = 'monero-request:2:H4sIAAAAAAAAAy1O206DQBD9FbOPpm0WWFrhDSo10WhiW7X2ZbOXoRBht9mLCsZ/dzHNPMycW+b8INZrrxzKUYQXGKMZEg1TJ6Ctkq1gThvqTRfkSfHGgBJDQC+723/COt3TjnGYLA6sC6zyPQdDdU3PbOhBOYvyCM/QBdFWBi8XROBVTQRZgoxrHnJWNCB9B0G9vrrMREPXgbH0i4U9FSWFSw6p+Xwdzntdn3oPT5nNnp0Z5RbS0sPG2I/i2EarUr/zZhysHkf9uCmX45vaP8i79bL4rgpeVakYN9ukCdc9tz1p1nCId9NLx4yjkrmpS4xjMsfZHKf7KMujmzxKFyTBR/T7BxO/cqM9AQAA'
+        request_string = 'monero-request:2:H4sIAAAAAAAA/y1O206DQBD9FbOPpm0WWFrhDSo10WhiW7X2ZbOXoRBht9mLCsZ/dzHNPMycW+b8INZrrxzKUYQXGKMZEg1TJ6Ctkq1gThvqTRfkSfHGgBJDQC+723/COt3TjnGYLA6sC6zyPQdDdU3PbOhBOYvyCM/QBdFWBi8XROBVTQRZgoxrHnJWNCB9B0G9vrrMREPXgbH0i4U9FSWFSw6p+Xwdzntdn3oPT5nNnp0Z5RbS0sPG2I/i2EarUr/zZhysHkf9uCmX45vaP8i79bL4rgpeVakYN9ukCdc9tz1p1nCId9NLx4yjkrmpS4xjMsfZHKf7KMujmzxKFyTBR/T7BxO/cqM9AQAA'
         self.assertEqual(decode_monero_payment_request(request_string), payment_request)
 
     def test_make_monero_payment_request_v2(self):
@@ -78,4 +78,4 @@ class TestMoneroRequest(unittest.TestCase):
         }
         request_string = make_monero_payment_request(**payment_request)
         self.maxDiff = None
-        self.assertEqual(request_string, 'monero-request:2:H4sIAAAAAAAAAy1O206DQBD9FbOPpm0WWFrhDSo10WhiW7X2ZbOXoRBht9mLCsZ/dzHNPMycW+b8INZrrxzKUYQXGKMZEg1TJ6Ctkq1gThvqTRfkSfHGgBJDQC+723/COt3TjnGYLA6sC6zyPQdDdU3PbOhBOYvyCM/QBdFWBi8XROBVTQRZgoxrHnJWNCB9B0G9vrrMREPXgbH0i4U9FSWFSw6p+Xwdzntdn3oPT5nNnp0Z5RbS0sPG2I/i2EarUr/zZhysHkf9uCmX45vaP8i79bL4rgpeVakYN9ukCdc9tz1p1nCId9NLx4yjkrmpS4xjMsfZHKf7KMujmzxKFyTBR/T7BxO/cqM9AQAA')
+        self.assertEqual(request_string, 'monero-request:2:H4sIAAAAAAAA/y1O206DQBD9FbOPpm0WWFrhDSo10WhiW7X2ZbOXoRBht9mLCsZ/dzHNPMycW+b8INZrrxzKUYQXGKMZEg1TJ6Ctkq1gThvqTRfkSfHGgBJDQC+723/COt3TjnGYLA6sC6zyPQdDdU3PbOhBOYvyCM/QBdFWBi8XROBVTQRZgoxrHnJWNCB9B0G9vrrMREPXgbH0i4U9FSWFSw6p+Xwdzntdn3oPT5nNnp0Z5RbS0sPG2I/i2EarUr/zZhysHkf9uCmX45vaP8i79bL4rgpeVakYN9ukCdc9tz1p1nCId9NLx4yjkrmpS4xjMsfZHKf7KMujmzxKFyTBR/T7BxO/cqM9AQAA')

--- a/test/test_monerorequest.py
+++ b/test/test_monerorequest.py
@@ -30,7 +30,7 @@ class TestMoneroRequest(unittest.TestCase):
             'currency': 'USD', 'amount': '10.00', 'payment_id': 'bc4c07f4c46ed2fb', 'start_date': '2024-09-05T19:18:15.430Z',
             'days_per_billing_cycle': 1, 'number_of_payments': 10, 'change_indicator_url': '', 'version': '1'
         }
-        request_string = 'monero-request:1:H4sIAAAAAAAA/y2OS0/DMBCE/4vPbeWkTktyS0qCBAKJtpTSi+XH5iEcu7IdIEH8dxzEaXe+Wc3ON2K9GbRHGYrwCmO0QKJlugHaadkJ5o2lg1XBnp3BWtBiDOrlcPsHnDc9VYzDfOLB+UAlGx29gqW8U6rTDRWjUICyaIH00PNgmJpe2diD9i5gvED/inYyxHBBBN7WRJANyLjmIdKBUmAd/WRhzmVJ7tfnxH6cxuvR1E0/wFPq0mdvJ7mHpBigsu49v3TRtjBvvJ1GZ6bJPFbFZnrVxwd5t9vkX2XOyzIRU7Vft2G7564n7Q7O8WF+6Zn1VDIfmqMYx2SJ0yVOjlGaRTdZlKzIGl/Qzy/yB8wvQQEAAA=='
+        request_string = 'monero-request:1:H4sIAAAAAAAAAy2OS0/DMBCE/4vPbeWkTktyS0qCBAKJtpTSi+XH5iEcu7IdIEH8dxzEaXe+Wc3ON2K9GbRHGYrwCmO0QKJlugHaadkJ5o2lg1XBnp3BWtBiDOrlcPsHnDc9VYzDfOLB+UAlGx29gqW8U6rTDRWjUICyaIH00PNgmJpe2diD9i5gvED/inYyxHBBBN7WRJANyLjmIdKBUmAd/WRhzmVJ7tfnxH6cxuvR1E0/wFPq0mdvJ7mHpBigsu49v3TRtjBvvJ1GZ6bJPFbFZnrVxwd5t9vkX2XOyzIRU7Vft2G7564n7Q7O8WF+6Zn1VDIfmqMYx2SJ0yVOjlGaRTdZlKzIGl/Qzy/yB8wvQQEAAA=='
         self.assertEqual(decode_monero_payment_request(request_string), payment_request)
 
     def test_make_monero_payment_request_v1(self):
@@ -41,7 +41,7 @@ class TestMoneroRequest(unittest.TestCase):
         }
         request_string = make_monero_payment_request(**payment_request)
         self.maxDiff = None
-        self.assertEqual(request_string, 'monero-request:1:H4sIAAAAAAAA/y2OS0/DMBCE/4vPbeWkTktyS0qCBAKJtpTSi+XH5iEcu7IdIEH8dxzEaXe+Wc3ON2K9GbRHGYrwCmO0QKJlugHaadkJ5o2lg1XBnp3BWtBiDOrlcPsHnDc9VYzDfOLB+UAlGx29gqW8U6rTDRWjUICyaIH00PNgmJpe2diD9i5gvED/inYyxHBBBN7WRJANyLjmIdKBUmAd/WRhzmVJ7tfnxH6cxuvR1E0/wFPq0mdvJ7mHpBigsu49v3TRtjBvvJ1GZ6bJPFbFZnrVxwd5t9vkX2XOyzIRU7Vft2G7564n7Q7O8WF+6Zn1VDIfmqMYx2SJ0yVOjlGaRTdZlKzIGl/Qzy/yB8wvQQEAAA==')
+        self.assertEqual(request_string, 'monero-request:1:H4sIAAAAAAAAAy2OS0/DMBCE/4vPbeWkTktyS0qCBAKJtpTSi+XH5iEcu7IdIEH8dxzEaXe+Wc3ON2K9GbRHGYrwCmO0QKJlugHaadkJ5o2lg1XBnp3BWtBiDOrlcPsHnDc9VYzDfOLB+UAlGx29gqW8U6rTDRWjUICyaIH00PNgmJpe2diD9i5gvED/inYyxHBBBN7WRJANyLjmIdKBUmAd/WRhzmVJ7tfnxH6cxuvR1E0/wFPq0mdvJ7mHpBigsu49v3TRtjBvvJ1GZ6bJPFbFZnrVxwd5t9vkX2XOyzIRU7Vft2G7564n7Q7O8WF+6Zn1VDIfmqMYx2SJ0yVOjlGaRTdZlKzIGl/Qzy/yB8wvQQEAAA==')
 
     def test_make_monero_payment_request_v1_w_defaults(self):
         payment_request = {
@@ -67,7 +67,7 @@ class TestMoneroRequest(unittest.TestCase):
             'currency': 'USD', 'amount': '10.00', 'payment_id': 'bc4c07f4c46ed2fb', 'start_date': '2024-09-05T19:18:15.430Z',
             'schedule': '* * * * *', 'number_of_payments': 10, 'change_indicator_url': '', 'version': '2'
         }
-        request_string = 'monero-request:2:H4sIAAAAAAAA/y1O206DQBD9FbOPpm0WWFrhDSo10WhiW7X2ZbOXoRBht9mLCsZ/dzHNPMycW+b8INZrrxzKUYQXGKMZEg1TJ6Ctkq1gThvqTRfkSfHGgBJDQC+723/COt3TjnGYLA6sC6zyPQdDdU3PbOhBOYvyCM/QBdFWBi8XROBVTQRZgoxrHnJWNCB9B0G9vrrMREPXgbH0i4U9FSWFSw6p+Xwdzntdn3oPT5nNnp0Z5RbS0sPG2I/i2EarUr/zZhysHkf9uCmX45vaP8i79bL4rgpeVakYN9ukCdc9tz1p1nCId9NLx4yjkrmpS4xjMsfZHKf7KMujmzxKFyTBR/T7BxO/cqM9AQAA'
+        request_string = 'monero-request:2:H4sIAAAAAAAAAy1O206DQBD9FbOPpm0WWFrhDSo10WhiW7X2ZbOXoRBht9mLCsZ/dzHNPMycW+b8INZrrxzKUYQXGKMZEg1TJ6Ctkq1gThvqTRfkSfHGgBJDQC+723/COt3TjnGYLA6sC6zyPQdDdU3PbOhBOYvyCM/QBdFWBi8XROBVTQRZgoxrHnJWNCB9B0G9vrrMREPXgbH0i4U9FSWFSw6p+Xwdzntdn3oPT5nNnp0Z5RbS0sPG2I/i2EarUr/zZhysHkf9uCmX45vaP8i79bL4rgpeVakYN9ukCdc9tz1p1nCId9NLx4yjkrmpS4xjMsfZHKf7KMujmzxKFyTBR/T7BxO/cqM9AQAA'
         self.assertEqual(decode_monero_payment_request(request_string), payment_request)
 
     def test_make_monero_payment_request_v2(self):
@@ -78,4 +78,4 @@ class TestMoneroRequest(unittest.TestCase):
         }
         request_string = make_monero_payment_request(**payment_request)
         self.maxDiff = None
-        self.assertEqual(request_string, 'monero-request:2:H4sIAAAAAAAA/y1O206DQBD9FbOPpm0WWFrhDSo10WhiW7X2ZbOXoRBht9mLCsZ/dzHNPMycW+b8INZrrxzKUYQXGKMZEg1TJ6Ctkq1gThvqTRfkSfHGgBJDQC+723/COt3TjnGYLA6sC6zyPQdDdU3PbOhBOYvyCM/QBdFWBi8XROBVTQRZgoxrHnJWNCB9B0G9vrrMREPXgbH0i4U9FSWFSw6p+Xwdzntdn3oPT5nNnp0Z5RbS0sPG2I/i2EarUr/zZhysHkf9uCmX45vaP8i79bL4rgpeVakYN9ukCdc9tz1p1nCId9NLx4yjkrmpS4xjMsfZHKf7KMujmzxKFyTBR/T7BxO/cqM9AQAA')
+        self.assertEqual(request_string, 'monero-request:2:H4sIAAAAAAAAAy1O206DQBD9FbOPpm0WWFrhDSo10WhiW7X2ZbOXoRBht9mLCsZ/dzHNPMycW+b8INZrrxzKUYQXGKMZEg1TJ6Ctkq1gThvqTRfkSfHGgBJDQC+723/COt3TjnGYLA6sC6zyPQdDdU3PbOhBOYvyCM/QBdFWBi8XROBVTQRZgoxrHnJWNCB9B0G9vrrMREPXgbH0i4U9FSWFSw6p+Xwdzntdn3oPT5nNnp0Z5RbS0sPG2I/i2EarUr/zZhysHkf9uCmX45vaP8i79bL4rgpeVakYN9ukCdc9tz1p1nCId9NLx4yjkrmpS4xjMsfZHKf7KMujmzxKFyTBR/T7BxO/cqM9AQAA')


### PR DESCRIPTION
Between my local environment and the CI environment, I was getting failing tests locally due to different python versions resulting in slightly different outputs. This was mostly a personal annoyance. If this causes annoying failures for others that want to develop this project, we can try to figure out a better way to handle this kind of error. We could potentially redesign these tests, or come up with a more robust version solution.